### PR TITLE
Fix flicker in most animated GIF

### DIFF
--- a/AnimatedGIFs.cpp
+++ b/AnimatedGIFs.cpp
@@ -110,7 +110,7 @@ void screenClearCallback(void) {
 }
 
 void updateScreenCallback(void) {
-  matrix.swapBuffers(false);
+  matrix.swapBuffers(true);
 }
 
 void drawPixelCallback(int16_t x, int16_t y, uint8_t red, uint8_t green, uint8_t blue) {


### PR DESCRIPTION
Hi Paul,

I set up an animated GIF panel in my son's room based on this demo of yours and initially I saw a lot of flicker in most GIF animations.

Eventually I found out that the `swapBuffers` needs to be called with the option to copy the current buffer into the next buffer after doing the swap, otherwise the frame get out of sync with the GIF decoder causing flicker.

Did you get this code from somewhere else or did you write it? It's really nice. It would be worth it to package this up as a demo app for the RGB shield.
